### PR TITLE
Add AI assistant feature

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -113,8 +113,11 @@
   </div>
 
   <!-- React App Root -->
-  <noscript>You need to enable JavaScript to run this app.</noscript>
-  <div id="root"></div>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+
+    <!-- Puter.js for free OpenAI API access -->
+    <script src="https://js.puter.com/v2/"></script>
 
   <script>
     // Hide splash and show app when loaded

--- a/src/App.js
+++ b/src/App.js
@@ -15,6 +15,7 @@ import SimulationScreen from './components/SimulationScreen';
 import NegotiationSystem from './components/NegotiationSystem';
 import TrainingDevelopment from './components/TrainingDevelopment';
 import SettingsSystem from './components/SettingsSystem';
+import AIAssistant from './components/AIAssistant';
 
 // Navigation and layout components
 import Navbar from './components/common/Navbar';
@@ -79,13 +80,17 @@ function MainApp() {
               path="/negotiation/:playerId/:clubId" 
               element={<NegotiationSystem />} 
             />
-            <Route 
-              path="/training" 
-              element={<TrainingDevelopment />} 
+            <Route
+              path="/training"
+              element={<TrainingDevelopment />}
             />
-            <Route 
-              path="/settings" 
-              element={<SettingsSystem />} 
+            <Route
+              path="/ai-assistant"
+              element={<AIAssistant />}
+            />
+            <Route
+              path="/settings"
+              element={<SettingsSystem />}
             />
           </Routes>
         </main>

--- a/src/components/AIAssistant.jsx
+++ b/src/components/AIAssistant.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+
+const AIAssistant = () => {
+  const [prompt, setPrompt] = useState('');
+  const [response, setResponse] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const sendPrompt = async () => {
+    if (!window.puter || !window.puter.ai) {
+      setResponse('Puter AI service not available.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await window.puter.ai.chat(prompt);
+      setResponse(typeof res === 'string' ? res : JSON.stringify(res));
+    } catch (err) {
+      console.error('AI error', err);
+      setResponse('Error getting response.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto bg-white p-4 rounded shadow">
+      <h2 className="text-xl font-bold mb-2">AI Assistant</h2>
+      <textarea
+        className="w-full border p-2 mb-2" rows="4"
+        value={prompt}
+        onChange={e => setPrompt(e.target.value)}
+        placeholder="Ask the AI about football strategies, player training, etc."
+      />
+      <button
+        onClick={sendPrompt}
+        className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        disabled={loading || !prompt.trim()}
+      >
+        {loading ? 'Thinking...' : 'Send'}
+      </button>
+      {response && (
+        <div className="mt-4 p-2 border rounded bg-gray-50 whitespace-pre-wrap">
+          {response}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AIAssistant;

--- a/src/components/PlayerManagement.jsx
+++ b/src/components/PlayerManagement.jsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
-import { ArrowUp, ArrowDown, TrendingUp, DollarSign, Activity, Calendar, Target, Award, UserPlus, RefreshCw } from 'lucide-react';
+import { ArrowUp, ArrowDown, TrendingUp, DollarSign, Activity, Calendar, Target, Award, UserPlus, RefreshCw, Sparkles } from 'lucide-react';
 
 const PlayerManagement = () => {
   const [selectedPlayer, setSelectedPlayer] = useState(null);
   const [viewMode, setViewMode] = useState('list'); // 'list' or 'details'
+  const [aiReport, setAiReport] = useState('');
+  const [aiLoading, setAiLoading] = useState(false);
 
   // Example player data (in a real app, this would come from game state)
   const players = [
@@ -126,6 +128,25 @@ const PlayerManagement = () => {
     if (overall >= 75) return 'bg-green-500 text-white';
     if (overall >= 65) return 'bg-yellow-500 text-white';
     return 'bg-red-500 text-white';
+  };
+
+  const generateAiReport = async () => {
+    if (!selectedPlayer) return;
+    if (!window.puter || !window.puter.ai) {
+      setAiReport('Puter AI service not available.');
+      return;
+    }
+    setAiLoading(true);
+    try {
+      const prompt = `Provide a short scouting report for ${selectedPlayer.name}, a ${selectedPlayer.age}-year-old ${selectedPlayer.position} from ${selectedPlayer.nationality}.`;
+      const res = await window.puter.ai.chat(prompt);
+      setAiReport(typeof res === 'string' ? res : JSON.stringify(res));
+    } catch (err) {
+      console.error(err);
+      setAiReport('Error fetching report.');
+    } finally {
+      setAiLoading(false);
+    }
   };
 
   return (
@@ -386,6 +407,19 @@ const PlayerManagement = () => {
                         <Calendar className="w-4 h-4" />
                         <span>Schedule Meeting</span>
                       </button>
+                      <button
+                        className="w-full mb-2 flex items-center justify-center space-x-2 bg-purple-600 hover:bg-purple-700 text-white py-2 px-4 rounded"
+                        onClick={generateAiReport}
+                      >
+                        <Sparkles className="w-4 h-4" />
+                        <span>AI Scout Report</span>
+                      </button>
+                      {aiLoading && <div className="text-sm text-gray-500">Generating report...</div>}
+                      {aiReport && (
+                        <div className="mt-2 p-2 border rounded bg-gray-50 whitespace-pre-wrap text-sm">
+                          {aiReport}
+                        </div>
+                      )}
                     </div>
                   </div>
                   

--- a/src/components/common/Sidebar.jsx
+++ b/src/components/common/Sidebar.jsx
@@ -10,6 +10,7 @@ import {
   Briefcase,
   Settings, 
   Dumbbell,
+  Sparkles,
   Menu,
   X
 } from 'lucide-react';
@@ -43,6 +44,7 @@ const Sidebar = ({ currentView, onNavigate }) => {
     { id: 'transfer-market', label: 'Transfer Market', icon: <DollarSign className="w-5 h-5" />, path: '/transfer-market' },
     { id: 'training', label: 'Training', icon: <Dumbbell className="w-5 h-5" />, path: '/training' },
     { id: 'simulation', label: 'Simulation', icon: <Calendar className="w-5 h-5" />, path: '/simulation' },
+    { id: 'ai-assistant', label: 'AI Assistant', icon: <Sparkles className="w-5 h-5" />, path: '/ai-assistant' },
     { id: 'awards-statistics', label: 'Awards & Stats', icon: <Trophy className="w-5 h-5" />, path: '/awards-statistics' },
     { id: 'settings', label: 'Settings', icon: <Settings className="w-5 h-5" />, path: '/settings' }
   ];


### PR DESCRIPTION
## Summary
- integrate Puter.js for free OpenAI access
- add AI assistant page with chat interface
- allow AI scouting reports for players
- expose AI assistant from sidebar navigation

## Testing
- `npm install --silent`
- `CI=true npm test -- --passWithNoTests --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684c1983d9b88328a62f24eb77d07a95